### PR TITLE
Add procps, decrease image size, and update docs to allow more complete monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,13 @@ FROM debian:squeeze
 
 ENV NEW_RELIC_LICENSE_KEY YOUR_LICENSE_KEY
 
-# apt-get update
-RUN apt-get update -q && apt-get install -yq ca-certificates wget
-
-# install new relic server monitoring
-RUN echo deb http://apt.newrelic.com/debian/ newrelic non-free >> /etc/apt/sources.list.d/newrelic.list && \
+# apt-get update, install newrelic server monitoring, and then clean
+RUN apt-get update -q && apt-get install -yq ca-certificates wget procps && \
+    echo deb http://apt.newrelic.com/debian/ newrelic non-free >> /etc/apt/sources.list.d/newrelic.list && \
     wget -O- https://download.newrelic.com/548C16BF.gpg | apt-key add - && \
     apt-get update -q && \
-    apt-get install -y -qq newrelic-sysmond
+    apt-get install -y -qq newrelic-sysmond && \
+    apt-get clean
 
 # supervisor
 RUN apt-get install -y -qq supervisor && \

--- a/README.md
+++ b/README.md
@@ -14,29 +14,22 @@ This Docker image is based on the official [debian:squeeze](https://index.docker
 
 ### docker run
 
+In order to give newrelic full access for monitoring there are a few unusual flags you'll need.
 
-    docker run -d -e NEW_RELIC_LICENSE_KEY=YOUR_NEW_RELIC_LICENSE_KEY -h `hostname` uzyexe/newrelic
+    docker run -d \
+        -v /var/run/docker.sock:/var/run/docker.sock:ro \
+        -e NEW_RELIC_LICENSE_KEY=YOUR_NEW_RELIC_LICENSE_KEY \
+        --privileged \
+        --pid="host" \
+        --net="host" \
+        --ipc="host" \
+        -v /sys:/sys \
+        -v /dev:/dev \
+        --restart=always \
+        --name newrelic \
+        uzyexe/newrelic
 
 --
-
-### cloud-config.yml
-
-      units: 
-        - name: newrelic.service
-          command: start
-          content: |
-            [Unit]
-            Description=newrelic
-            
-            [Service]
-            Restart=always
-            RestartSec=300
-            TimeoutStartSec=10m
-            ExecStartPre=-/usr/bin/docker stop newrelic
-            ExecStartPre=-/usr/bin/docker rm -f newrelic
-            ExecStartPre=/usr/bin/docker pull uzyexe/newrelic
-            ExecStart=/bin/bash -c '/usr/bin/docker run --rm --name newrelic --env="NEW_RELIC_LICENSE_KEY=YOUR_NEW_RELIC_LICENSE_KEY" -h `/usr/bin/hostname` uzyexe/newrelic'
-            ExecStop=/usr/bin/docker stop newrelic
 
 
 ## New Relic


### PR DESCRIPTION
newrelic now has support for monitoring docker containers; also, recommended ways to start docker containers on reboot have changed.  Additionally, the newrelic monitor wants the "ps" command to work and should be able to monitor all processes on the system but currently can't, so docs were updated to mount needed dirs and docker.sock to make all that work.

I also compressed the run commands to decrease the image size (every run command adds a new image)
